### PR TITLE
fix: normalize DateTime UTC in meetings and improve carnival block member creation

### DIFF
--- a/.github/workflows/main_bloconarua-dev.yml
+++ b/.github/workflows/main_bloconarua-dev.yml
@@ -55,7 +55,7 @@ jobs:
           name: .net-app
 
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_AEF6EA8FCDC945E19C1EF331C3B3ACC0 }}
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_E06C275C4C674E7F8904C85F82F3EB80 }}

--- a/BlocoNaRua.Data/Repositories/MeetingsRepository.cs
+++ b/BlocoNaRua.Data/Repositories/MeetingsRepository.cs
@@ -25,6 +25,8 @@ public class MeetingsRepository(AppDbContext appContext) : RepositoryBase<Meetin
     {
         entity.CreatedAt = DateTime.UtcNow;
         entity.UpdatedAt = entity.CreatedAt;
+        if (entity.MeetingDateTime.HasValue && entity.MeetingDateTime.Value.Kind == DateTimeKind.Unspecified)
+            entity.MeetingDateTime = DateTime.SpecifyKind(entity.MeetingDateTime.Value, DateTimeKind.Utc);
         var result = await DbSet.AddAsync(entity, ct);
         await AppDbContext.SaveChangesAsync(ct);
         return result.Entity;
@@ -33,6 +35,8 @@ public class MeetingsRepository(AppDbContext appContext) : RepositoryBase<Meetin
     public async Task<bool> UpdateAsync(MeetingEntity entity, CancellationToken ct)
     {
         entity.UpdatedAt = DateTime.UtcNow;
+        if (entity.MeetingDateTime.HasValue && entity.MeetingDateTime.Value.Kind == DateTimeKind.Unspecified)
+            entity.MeetingDateTime = DateTime.SpecifyKind(entity.MeetingDateTime.Value, DateTimeKind.Utc);
         DbSet.Update(entity);
         return await AppDbContext.SaveChangesAsync(ct) > 0;
     }

--- a/BlocoNaRua.Restful/Controllers/CarnivalBlockMembersController.cs
+++ b/BlocoNaRua.Restful/Controllers/CarnivalBlockMembersController.cs
@@ -51,7 +51,7 @@ public class CarnivalBlockMembersController(ICarnivalBlockMembersService carniva
             if (blockMember == null)
                 return BadRequest();
 
-            var memberId = await _memberIdentityService.GetMemberIdAsync();
+            var memberId = blockMember.MemberId ?? await _memberIdentityService.GetMemberIdAsync();
 
             var entity = new CarnivalBlockMembersEntity(
                 id: 0,

--- a/BlocoNaRua.Restful/Models/CarnivalBlockMember/CarnivalBlockMemberCreate.cs
+++ b/BlocoNaRua.Restful/Models/CarnivalBlockMember/CarnivalBlockMemberCreate.cs
@@ -5,5 +5,6 @@ namespace BlocoNaRua.Restful.Models.CarnivalBlockMember;
 public record class CarnivalBlockMemberCreate
 (
     int CarnivalBlockId,
-    RolesEnum Role
+    RolesEnum Role,
+    int? MemberId
 );

--- a/BlocoNaRua.Services/Implementations/CarnivalBlockMembersService.cs
+++ b/BlocoNaRua.Services/Implementations/CarnivalBlockMembersService.cs
@@ -69,6 +69,12 @@ public class CarnivalBlockMembersService
             throw new UnauthorizedAccessException("Member is not authorized to add members.");
         }
 
+        var existing = await _repository.GetByBlockIdAsync(carnivalBlockMember.CarnivalBlockId, CancellationToken.None);
+        if (existing.Any(m => m.MemberId == carnivalBlockMember.MemberId))
+        {
+            throw new InvalidOperationException("Member is already part of this carnival block.");
+        }
+
         await _repository.AddAsync(carnivalBlockMember, CancellationToken.None);
         _cache.Remove($"CarnivalBlockMembers_Member_{carnivalBlockMember.MemberId}"); // Invalida o cache
     }

--- a/BlocoNaRua.Tests/Restful/CarnivalBlockMembersControllerTests.cs
+++ b/BlocoNaRua.Tests/Restful/CarnivalBlockMembersControllerTests.cs
@@ -62,10 +62,7 @@ public class CarnivalBlockMembersControllerTests
     {
         // Arrange
         _memberIdentityServiceMock.Setup(s => s.GetMemberIdAsync()).ReturnsAsync(1);
-        var createDto = new CarnivalBlockMemberCreate(
-            CarnivalBlockId: 1,
-            Role: RolesEnum.Member
-        );
+        var createDto = new CarnivalBlockMemberCreate(1, RolesEnum.Member, null);
 
         var controller = CreateController();
 
@@ -97,10 +94,7 @@ public class CarnivalBlockMembersControllerTests
     {
         // Arrange
         _memberIdentityServiceMock.Setup(s => s.GetMemberIdAsync()).ReturnsAsync(1);
-        var createDto = new CarnivalBlockMemberCreate(
-            CarnivalBlockId: 1,
-            Role: RolesEnum.Member
-        );
+        var createDto = new CarnivalBlockMemberCreate(1, RolesEnum.Member, null);
 
         _serviceMock.Setup(s => s.CreateAsync(It.IsAny<CarnivalBlockMembersEntity>(), It.IsAny<int>()))
             .ThrowsAsync(new KeyNotFoundException("Member does not exist."));
@@ -120,10 +114,7 @@ public class CarnivalBlockMembersControllerTests
     {
         // Arrange
         _memberIdentityServiceMock.Setup(s => s.GetMemberIdAsync()).ReturnsAsync(1);
-        var createDto = new CarnivalBlockMemberCreate(
-            CarnivalBlockId: 999,
-            Role: RolesEnum.Member
-        );
+        var createDto = new CarnivalBlockMemberCreate(999, RolesEnum.Member, null);
 
         _serviceMock.Setup(s => s.CreateAsync(It.IsAny<CarnivalBlockMembersEntity>(), It.IsAny<int>()))
             .ThrowsAsync(new KeyNotFoundException("Carnival block does not exist."));
@@ -143,10 +134,7 @@ public class CarnivalBlockMembersControllerTests
     {
         // Arrange
         _memberIdentityServiceMock.Setup(s => s.GetMemberIdAsync()).ReturnsAsync(1);
-        var createDto = new CarnivalBlockMemberCreate(
-            CarnivalBlockId: 1,
-            Role: RolesEnum.Member
-        );
+        var createDto = new CarnivalBlockMemberCreate(1, RolesEnum.Member, null);
 
         _serviceMock.Setup(s => s.CreateAsync(It.IsAny<CarnivalBlockMembersEntity>(), It.IsAny<int>()))
             .ThrowsAsync(new InvalidOperationException("Something went wrong"));

--- a/BlocoNaRua.Tests/Services/CarnivalBlockMembersServiceTests.cs
+++ b/BlocoNaRua.Tests/Services/CarnivalBlockMembersServiceTests.cs
@@ -142,7 +142,16 @@ public class CarnivalBlockMembersServiceTests : IDisposable
         // Arrange
         await AddData(1, 101, "Block 1", 101, RolesEnum.Owner);
         await AddData(1, 101, "Block 1", 102, RolesEnum.Member);
-        var newBlockMember = new CarnivalBlockMembersEntity(0, 1, 102, RolesEnum.Member);
+        // Add member 103 entity directly (not as block member) so service can add them
+        await _membersRepository.AddAsync(new MemberEntity(
+            id: 103,
+            name: "New Member",
+            email: "new@test.com",
+            phone: "1234567890",
+            profileImage: "profile_image.jpg",
+            uuid: new Guid()
+        ));
+        var newBlockMember = new CarnivalBlockMembersEntity(0, 1, 103, RolesEnum.Member);
 
         // Act
         await _carnivalBlockMembersService.CreateAsync(newBlockMember, 101);


### PR DESCRIPTION
## Changes

- **MeetingsRepository**: Normalize MeetingDateTime to UTC before saving to PostgreSQL (fixes 'Kind=Unspecified' error)
- **CarnivalBlockMemberCreate**: Add optional MemberId to request body
- **CarnivalBlockMembersController**: Fallback to _memberIdentityService when body MemberId is null
- **CarnivalBlockMembersService**: Add duplicate membership check before insert

## DB migrations applied
- Fixed cascade delete constraints on carnival_block_members, meetings, meeting_presences
- Added unique constraint on (carnival_block_id, member_id)